### PR TITLE
ci: drop `mdbook-rustviz --help` smoke test (it exits non-zero)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,14 @@ jobs:
             cargo install --path ../plugin-src/rustviz2-plugin --locked
             cargo install --path ../plugin-src/mdbook-rustviz --locked
           fi
-          mdbook-rustviz --help >/dev/null && echo "mdbook-rustviz OK"
+          # Just confirm the binaries are on PATH. Avoid `--help`:
+          # mdbook-rustviz's main returns clap's DisplayHelp via `?`,
+          # which exits non-zero (clap's error printer emits the help
+          # text but treats it as an error). The real usage shape
+          # (`mdbook-rustviz supports html` + stdin protocol) is
+          # exercised by the `mdbook build` step below.
+          command -v mdbook-rustviz
+          command -v cargo-rv-plugin
 
       - name: Build the book
         env:


### PR DESCRIPTION
Follow-up to #15. The smoke check `mdbook-rustviz --help >/dev/null` exits 1 because the plugin's main returns clap's `DisplayHelp` via `?` (it routes the help text through clap's error path). That broke the deploy workflow.

Real usage (`mdbook build` → `mdbook-rustviz supports html` + JSON-on-stdin) is unaffected; replace the broken check with a plain `command -v` existence test. The actual integration test is the `mdbook build` step that runs immediately after.