### PR TITLE
ci: point plugin source at rustviz/rustviz (consolidation follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,9 @@ jobs:
       # the toolchain. Keep this in sync with `rust-toolchain.toml`
       # in the rustviz/rustviz repo.
       RUST_NIGHTLY: nightly-2025-08-20
-      # The plugin source repo. Today the workspace lives at
-      # rustviz/rustviz2; we clone its main and `cargo install
-      # --path` the two binaries we need.
-      PLUGIN_REPO: rustviz/rustviz2
+      # The plugin source repo. We clone its main and
+      # `cargo install --path` the two binaries we need.
+      PLUGIN_REPO: rustviz/rustviz
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary

Companion to [rustviz/rustviz#57](https://github.com/rustviz/rustviz/pull/57), which merges the RustViz 2 codebase into \`rustviz/rustviz\`. After that PR lands, the plugin source for the tutorial deploy workflow needs to follow.

## Change

\`\`\`diff
-      # The plugin source repo. Today the workspace lives at
-      # rustviz/rustviz2; we clone its main and \`cargo install
-      # --path\` the two binaries we need.
-      PLUGIN_REPO: rustviz/rustviz2
+      # The plugin source repo. We clone its main and
+      # \`cargo install --path\` the two binaries we need.
+      PLUGIN_REPO: rustviz/rustviz
\`\`\`

## Order of merge

This PR should land **after** rustviz/rustviz#57. Until then the workflow's \`rustviz/rustviz2\` URL still works (the old repo will remain accessible as an archive after consolidation).

If rustviz/rustviz#57 is merged but this PR isn't, the deploy workflow keeps building successfully against the rustviz/rustviz2 archive. So no urgency, but worth tracking.