### PR TITLE
docs: hide compare_strings and clear_string in Hands-on tutorial

### DIFF
--- a/src/motivation.md
+++ b/src/motivation.md
@@ -47,11 +47,11 @@ fn main() {
     clear_string(r3);
 }
 
-fn compare_strings(s1: &String, s2: &String) -> bool {
+fn compare_strings(s1: &String, s2: &String) -> bool { // rustviz: hide
     *s1 == *s2
 }
 
-fn clear_string(s3: &mut String) {
+fn clear_string(s3: &mut String) { // rustviz: hide
     s3.clear();
 }
 ```


### PR DESCRIPTION
## Summary
The Hands-on tutorial in motivation.md renders three side-by-side timeline panels — one for `main`, one for `compare_strings`, one for `clear_string`. Only `main` is what the surrounding prose actually teaches; the helper bodies are shown for completeness but their visualizations are visual noise at the introduction.

Mark both helpers with the new \`// rustviz: hide\` form (rustviz/rustviz#69) so the plugin drops their definitions from the rendered code panel. The calls in \`main\` keep their fn-name coloring and the parameter-pass arrows still render — which is what the chapter prose refers to.

## Depends on
[rustviz/rustviz#69](https://github.com/rustviz/rustviz/pull/69) — adds the \`hide\` marker. Won't visualize correctly here until that lands and the runner image picks it up.

## Test plan
- [ ] After rustviz/rustviz#69 merges and the prebuilt runner image rebuilds, mdBook build shows a single \`main\` panel for this snippet (not three)
- [ ] All other rv-blocks in the chapter still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)